### PR TITLE
feat: add generate-command

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/outillage/oto-tools/internal/generaterunner"
+	"github.com/outillage/oto-tools/internal/npm"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +21,26 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+
+	var generateCmd = &cobra.Command{
+		Use:   "generate",
+		Short: "Generates package json",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner := generaterunner.Runner{}
+
+			path := cmd.Flag("path").Value.String()
+			packageName := cmd.Flag("package-name").Value.String()
+			packageVersion := cmd.Flag("package-version").Value.String()
+
+			return runner.Run(path, npm.Package{Name: packageName, Version: packageVersion})
+		},
+	}
+	generateCmd.PersistentFlags().String("path", "./js", "set path for output of package.json")
+	generateCmd.PersistentFlags().String("package-name", "", "set name of project in package.json")
+	generateCmd.PersistentFlags().String("package-version", "", "set version of project in package.json")
+
+	rootCmd.AddCommand(generateCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/internal/generaterunner/.gitignore
+++ b/internal/generaterunner/.gitignore
@@ -1,0 +1,2 @@
+# used for outputing example js files
+jstest

--- a/internal/generaterunner/run.go
+++ b/internal/generaterunner/run.go
@@ -1,0 +1,35 @@
+package generaterunner
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	"github.com/outillage/oto-tools/internal/npm"
+)
+
+func (runner *Runner) Run(path string, packageOptions npm.Package) error {
+	if path == "" {
+		return errors.New("path can't be empty")
+	}
+
+	npmPackage, err := npm.GeneratePackageInfo(packageOptions)
+
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(path, 0777)
+
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(path+"/package.json", npmPackage, 0777)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/generaterunner/run_test.go
+++ b/internal/generaterunner/run_test.go
@@ -1,0 +1,35 @@
+package generaterunner
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/outillage/oto-tools/internal/npm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	runner := &Runner{}
+
+	emptyPathErr := runner.Run("", npm.Package{})
+
+	assert.Error(t, emptyPathErr)
+
+	err := runner.Run("./jstest", npm.Package{Name: "test-package", Version: "0.0.1"})
+
+	assert.NoError(t, err)
+
+	file, fileErr := ioutil.ReadFile("./jstest/package.json")
+
+	assert.NoError(t, fileErr)
+
+	generatedPackage := npm.Package{}
+
+	jsonErr := json.Unmarshal(file, &generatedPackage)
+
+	assert.NoError(t, jsonErr)
+
+	assert.Equal(t, "test-package", generatedPackage.Name)
+	assert.Equal(t, "0.0.1", generatedPackage.Version)
+}

--- a/internal/generaterunner/runner.go
+++ b/internal/generaterunner/runner.go
@@ -1,0 +1,4 @@
+package generaterunner
+
+type Runner struct {
+}


### PR DESCRIPTION
Adds the generate command which just outputs the package.json right now. 

Can be tested by running `oto-tools generate`. Usage is provided under `oto-tools generate --help`.

Refs #1