### PR TITLE
feat: publish to NPM commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x, 1.14.x]
 
     steps:
       - name: Install Go

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/outillage/oto-tools/internal/generaterunner"
 	"github.com/outillage/oto-tools/internal/npm"
+	"github.com/outillage/oto-tools/internal/publishrunner"
 	"github.com/outillage/oto-tools/internal/versioning"
 	"github.com/spf13/cobra"
 )
@@ -54,6 +55,30 @@ func main() {
 	generateCmd.PersistentFlags().String("oto-definitions", "", "path to oto definition")
 
 	rootCmd.AddCommand(generateCmd)
+
+	var NPMPublishCmd = &cobra.Command{
+		Use:   "publish-npm",
+		Short: "Publishes provided package to NPM",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner := publishrunner.Runner{}
+
+			path := cmd.Flag("path").Value.String()
+			token := cmd.Flag("token").Value.String()
+
+			return runner.Run(
+				path,
+				npm.PublishOptions{
+					Token: token,
+				},
+			)
+		},
+	}
+
+	NPMPublishCmd.PersistentFlags().String("path", "./js", "set path for js library to publish")
+	NPMPublishCmd.PersistentFlags().String("token", "", "token for authenticating against NPM")
+
+	rootCmd.AddCommand(NPMPublishCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/internal/npm/publish.go
+++ b/internal/npm/publish.go
@@ -1,0 +1,37 @@
+package npm
+
+import (
+	"errors"
+
+	"github.com/magefile/mage/sh"
+)
+
+type PublishOptions struct {
+	Token   string
+	DryRun  bool
+	Private bool
+}
+
+func Publish(path string, options PublishOptions) error {
+	var command []string
+
+	command = append(command, "publish", path)
+
+	if options.Token == "" {
+		return errors.New("missing NPM token")
+	}
+
+	if options.DryRun {
+		command = append(command, "--dry-run")
+	}
+
+	env := map[string]string{
+		"NPM_TOKEN": options.Token,
+	}
+
+	if !options.Private {
+		command = append(command, "--access", "public")
+	}
+
+	return sh.RunWith(env, "npm", command...)
+}

--- a/internal/publishrunner/cleanup.go
+++ b/internal/publishrunner/cleanup.go
@@ -1,0 +1,15 @@
+package publishrunner
+
+import (
+	"log"
+	"os"
+)
+
+// cleanup removes authentication files after publishing.
+func cleanup() {
+	err := os.Remove("./.npmrc")
+
+	if err != nil {
+		log.Printf("Failed to clean up authentication files %v", err)
+	}
+}

--- a/internal/publishrunner/create_config.go
+++ b/internal/publishrunner/create_config.go
@@ -1,0 +1,12 @@
+package publishrunner
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+func createConfigFile(path, registry, token string) error {
+	contents := fmt.Sprintf("%s:_authToken=%s", registry, token)
+
+	return ioutil.WriteFile("./.npmrc", []byte(contents), 0777)
+}

--- a/internal/publishrunner/run.go
+++ b/internal/publishrunner/run.go
@@ -1,0 +1,31 @@
+package publishrunner
+
+import (
+	"log"
+
+	"github.com/outillage/oto-tools/internal/npm"
+)
+
+const (
+	// NPMRegistry is the default registry url for most JS projects.
+	NPMRegistry = "//registry.npmjs.org/"
+)
+
+// Run executes the full publish command. It will create a .npmrc file, publish to NPM and then delete the .npmrc file.
+func (runner *Runner) Run(path string, options npm.PublishOptions) error {
+	err := createConfigFile(path, NPMRegistry, options.Token)
+
+	if err != nil {
+		return err
+	}
+
+	err = npm.Publish(path, options)
+
+	if err != nil {
+		log.Printf("Failed to publish to npm %v", err)
+	}
+
+	cleanup()
+
+	return err
+}

--- a/internal/publishrunner/runner.go
+++ b/internal/publishrunner/runner.go
@@ -1,0 +1,5 @@
+package publishrunner
+
+// Runner is the default struct which houses any dependencies
+type Runner struct {
+}


### PR DESCRIPTION
- adds publish-npm command
- registers command in main.go
- adds flow for publishing to NPM
- adds npm config creation and deletion

Closes #3 