### PR TITLE
fix: clean generated version

### DIFF
--- a/internal/versioning/clean_version.go
+++ b/internal/versioning/clean_version.go
@@ -1,0 +1,11 @@
+package versioning
+
+import "strings"
+
+func cleanVersion(version string) string {
+	version = strings.TrimPrefix(version, "/refs/tags/")
+
+	version = strings.TrimLeft(version, "v")
+
+	return version
+}

--- a/internal/versioning/clean_version_test.go
+++ b/internal/versioning/clean_version_test.go
@@ -1,0 +1,20 @@
+package versioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanVersion(t *testing.T) {
+	tests := map[string]string{
+		"/refs/tags/v0.0.1": "0.0.1",
+		"v0.0.2":            "0.0.2",
+		"0.0.3":             "0.0.3",
+	}
+
+	for test, expected := range tests {
+		assert.Equal(t, expected, cleanVersion(test))
+	}
+
+}

--- a/internal/versioning/find_version.go
+++ b/internal/versioning/find_version.go
@@ -19,7 +19,7 @@ func FindVersion() string {
 	currentTag, err := gitRepo.CurrentTag()
 
 	if err == nil {
-		return currentTag.Name
+		return cleanVersion(currentTag.Name)
 	}
 
 	if err != nil && err != git.ErrCommitNotOnTag {
@@ -38,5 +38,5 @@ func FindVersion() string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s-%s", previousTag.Name, currentCommit.Hash)
+	return fmt.Sprintf("%s-%s", cleanVersion(previousTag.Name), currentCommit.Hash)
 }


### PR DESCRIPTION
/refs/tags was prepended in the name.